### PR TITLE
Creating configMaps and secrets.yml

### DIFF
--- a/kubernetes/configMap_secrets.yml
+++ b/kubernetes/configMap_secrets.yml
@@ -1,0 +1,112 @@
+### Development
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config-dev
+  namespace: development
+data: 
+  NEXT_PUBLIC_API_URL: "http://localhost:8706"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-secret-dev
+  namespace: development
+data:
+  NEXT_APP_API_KEY: "ZmVyZ2Roa2Rza2dsZGtkZA==" #value in Base64
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config-dev
+  namespace: development
+data:
+  PORT: "8706"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-secrets-dev
+  namespace: development
+data:
+  REDIS_PASSWORD: "c29tZXJlZGlzcGFzc3dvcmQ="   #value in Base64
+  DATABASE_URI: "bW9uZ29kYjovL2xvY2FsaG9zdDoyNzAxNw==" #value in Base64
+
+
+# ### Staging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config-stage
+  namespace: staging
+data: 
+  NEXT_PUBLIC_API_URL: "http://localhost:8706"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-secrets-stage
+  namespace: staging
+data:
+  NEXT_APP_API_KEY: "ZmVyZ2Roa2Rza2dsZGtkZA==" #value in Base64
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config-stage
+  namespace: staging
+data:
+  PORT: "8706"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-secrets-stage
+  namespace: staging
+data:
+  REDIS_PASSWORD: "c29tZXJlZGlzcGFzc3dvcmQ="   #value in Base64
+  DATABASE_URI: "bW9uZ29kYjovL2xvY2FsaG9zdDoyNzAxNw==" #value in Base64
+
+
+# ## Production
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config-prod
+  namespace: production
+data: 
+  NEXT_PUBLIC_API_URL: "http://localhost:8706"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-secrets-prod
+  namespace: production
+data:
+  NEXT_APP_API_KEY: "ZmVyZ2Roa2Rza2dsZGtkZA==" #value in Base64
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config-prod
+  namespace: production
+data:
+  PORT: "8706"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-secrets-prod
+  namespace: production
+data:
+  REDIS_PASSWORD: "c29tZXJlZGlzcGFzc3dvcmQ="   #value in Base64
+  DATABASE_URI: "bW9uZ29kYjovL2xvY2FsaG9zdDoyNzAxNw==" #value in Base64
+


### PR DESCRIPTION
For security purpose decouple sensetive and non-sensitive data from deployment and creating one file with configMap.yml (non sensitive data) & secret.yml (sensetive data)

While running the deployment, the containers/pods refering to the configMap and secret.yml for retrieving specific data

Inside file - there is the definition of the configMap and secrets for each namespaces